### PR TITLE
Removal of Zbu Models Builder package

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Please note * indicates that the package is commercial or may require a license 
 ## Code Libraries
 
 * [Ditto](https://our.umbraco.org/projects/developer-tools/ditto/) - a lightweight model mapper for `IPublishedContent`.
-* [Zbu Models Builder](https://github.com/zpqrtbnk/Zbu.ModelsBuilder) - generate strongly-typed `IPublishedContent` models automagically.
 * [Umbraco Core Property Value Converters](https://our.umbraco.org/projects/developer-tools/umbraco-core-property-value-converters) - implements converters for the Umbraco Core property-editors.
 * [Skybrud.Umbraco.GridData](https://our.umbraco.org/projects/developer-tools/skybrudumbracogriddata/) - a package for making the Umbraco grid strongly typed.
 


### PR DESCRIPTION
Since the **Zbu Models Builder** package has been included with Umbraco since v7.4.0, it doesn't need to be promoted as a standalone package.