### PR TITLE
Removal of Umbraco Core Property Value Converters library

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Please note * indicates that the package is commercial or may require a license 
 
 * [Ditto](https://our.umbraco.org/projects/developer-tools/ditto/) - a lightweight model mapper for `IPublishedContent`.
 * [Zbu Models Builder](https://github.com/zpqrtbnk/Zbu.ModelsBuilder) - generate strongly-typed `IPublishedContent` models automagically.
-* [Umbraco Core Property Value Converters](https://our.umbraco.org/projects/developer-tools/umbraco-core-property-value-converters) - implements converters for the Umbraco Core property-editors.
 * [Skybrud.Umbraco.GridData](https://our.umbraco.org/projects/developer-tools/skybrudumbracogriddata/) - a package for making the Umbraco grid strongly typed.
 
 ## Umbraco products


### PR DESCRIPTION
> **Note:** I'm opening this PR in preparation, I wouldn't merge it in until after Umbraco v7.6 has been released.

With the upcoming release of Umbraco v7.6, the **Umbraco Core Property Value Converters** library is included in the core.

For the same reasons as #21 (Zbu Models Builder), we shouldn't need to promoted this as a standalone package/library.
